### PR TITLE
fix: Remove leading slash to support prefixed Foundry instances

### DIFF
--- a/__tests__/src/lib/utils.spec.js
+++ b/__tests__/src/lib/utils.spec.js
@@ -149,12 +149,12 @@ describe('fetchModuleData', () => {
 
     await Promise.allSettled([barPromise, bazPromise]).then(() => {
       expect(foundry.utils.fetchJsonWithTimeout).toHaveBeenCalledWith(
-        '/modules/wfrp4e-more-subspecies/data/bar-hash.json'
+        'modules/wfrp4e-more-subspecies/data/bar-hash.json'
       );
       expect(consoleLog).toHaveBeenCalledWith('Loaded bar');
 
       expect(foundry.utils.fetchJsonWithTimeout).toHaveBeenCalledWith(
-        '/modules/wfrp4e-more-subspecies/data/baz-hash.json'
+        'modules/wfrp4e-more-subspecies/data/baz-hash.json'
       );
       expect(consoleLog).toHaveBeenCalledWith('Loaded baz');
 
@@ -225,7 +225,7 @@ describe('fetchModuleData', () => {
 
     await Promise.allSettled([barPromise]).then(() => {
       expect(foundry.utils.fetchJsonWithTimeout).toHaveBeenCalledWith(
-        '/modules/wfrp4e-more-subspecies/data/bar-hash.json'
+        'modules/wfrp4e-more-subspecies/data/bar-hash.json'
       );
       expect(consoleLog).toHaveBeenCalledWith('Failed to load bar');
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -81,7 +81,7 @@ export async function fetchModuleData() {
 
   const responses = await Promise.allSettled(
     missingFiles.map(filename =>
-      foundry.utils.fetchJsonWithTimeout(`/modules/${MODULE.ID}/data/${filename}.json`)
+      foundry.utils.fetchJsonWithTimeout(`modules/${MODULE.ID}/data/${filename}.json`)
     )
   );
 


### PR DESCRIPTION
Solves https://github.com/mcavallo/foundry-vtt-wfrp4e-more-subspecies/issues/22